### PR TITLE
Adding Travis CI configuration for automatic testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: python
 
-# Build inside virtualbox rather than docker containers. This means the build
-# is slower to start, but the upside is that sudo is supported. In particular
-# this means that we can use apt-get to install the keyutils dependency:
-sudo: true
-
 python:
   - "2.6"
   - "2.7"
@@ -13,10 +8,17 @@ python:
   - "3.5"
   - "3.6"
 
-before_install:
-  # Installation step for non-python dependencies. The virtualenv is not
-  # activated at this point.
-  - sudo apt-get install libkeyutils-dev
+# Build inside docker containers instead of virtual machines. These are
+# faster, start quicker and support caching. Only downside: sudo is not
+# supported.
+sudo: false
+
+# Dependencies can be installed as follows. This works only for packages
+# whitelisted on https://github.com/travis-ci/apt-package-whitelist:
+addons:
+  apt:
+    packages:
+    - libkeyutils-dev
 
 install:
   # Installation step for the python package itself:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,11 @@ addons:
 
 install:
   # Installation step for the python package itself:
+  - pip install pytest
   - python setup.py install
+  # Note, when running via py.test, we have to prevent importing keyutils from
+  # current directory which doesn't contain the shared object:
+  - rm -r keyutils
 
 script:
-  - python test/keyutils_test.py
+  - py.test -v test/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+
+# Build inside virtualbox rather than docker containers. This means the build
+# is slower to start, but the upside is that sudo is supported. In particular
+# this means that we can use apt-get to install the keyutils dependency:
+sudo: true
+
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
+before_install:
+  # Installation step for non-python dependencies. The virtualenv is not
+  # activated at this point.
+  - sudo apt-get install libkeyutils-dev
+
+install:
+  # Installation step for the python package itself:
+  - python setup.py install
+
+script:
+  - python test/keyutils_test.py


### PR DESCRIPTION
**Just in case you are not yet familiar with Travis:**

Travis is a continuous integration service that allows automatic testing of the package on multiple python versions on every update of a upstream branch or pull request. The reports looks like [this](https://travis-ci.org/coldfix/python-keyutils). For this patch to be useful, you will have to create a Travis account.

**Further remarks:**

Give me a heads-up if you're also interested in coverage reports on coverage.io (as done [here](https://coveralls.io/github/hibtc/cpymad) for another repo).

As soon as `libkeyutils-dev` is added to the white list (see https://github.com/travis-ci/apt-package-whitelist/issues/1789), the following substitution should be done to speed up the tests:

replace

``` yaml
sudo: true

before_install:
  - sudo apt-get install libkeyutils-dev
```

by

``` yaml
sudo: false

addons:
  apt:
    packages:
    - libkeyutils-dev
```
