### PR TITLE
fix open() call when the default encoding is not utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,9 @@
 
 
 from distutils.core import setup, Extension
+import io
 
-with open('README.rst') as f:
+with io.open('README.rst', encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=811301
> I: pybuild base:184: python3.4 setup.py clean
> Traceback (most recent call last):
>   File "setup.py", line 22, in <module>
>     long_description = f.read()
>   File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode
>     return codecs.ascii_decode(input, self.errors)[0]
> UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1189: ordinal not in range(128)
> E: pybuild pybuild:274: clean: plugin distutils failed with: exit code=1: python3.4 setup.py clean
> dh_auto_clean: pybuild --clean -i python{version} -p 3.4 3.5 --dir . returned exit code 13