### PR TITLE
remove non-ascii ellipse from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ For example:
     assert keyutils.request_key(name, ring) == key_id
     assert keyutils.read_key(key_id) == value
 
-    # set timeout to 5 seconds, wait and then… it's gone:
+    # set timeout to 5 seconds, wait and then... it's gone:
     keyutils.set_timeout(key_id, 5)
     from time import sleep
     sleep(6)


### PR DESCRIPTION
makes the example break for some python interpreter environments, also causes error installing in some environments:

```
Collecting keyutils
  Using cached keyutils-0.3.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-3mr_h2x4/keyutils/setup.py", line 22, in <module>
        long_description = f.read()
      File "/opt/pythons/3.5.1/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1189: ordinal not in range(128)
```