### PR TITLE
Convert to setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.cache/
+.tox/
+.eggs/
 build/
 dist/
 MANIFEST

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
+[aliases]
+test=pytest
+
 [bdist_rpm]
 release = 1
 doc_files = AUTHORS ChangeLog INSTALL LICENSE README.rst
 build_requires = keyutils-libs-devel
 requires = python keyutils-libs
-
-[pytest]
-python_files=test*.py

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
     url='https://github.com/sassoftware/python-keyutils',
     license='Apache 2.0',
     packages=['keyutils'],
-    test_suite='test',
     classifiers=[
         "Topic :: Security",
         "Operating System :: POSIX :: Linux",
@@ -50,6 +49,8 @@ setup(
             'keyutils._keyutils',
             ['keyutils/_keyutils.c'],
             libraries=['keyutils'],
-        )
+        ),
     ],
+    setup_requires=["pytest-runner"],
+    tests_require=["pytest"],
 )


### PR DESCRIPTION
To provide the ability to run tests via `python setup.py test`, we need
to use setuptools.

Fixes #18

Signed-off-by: Walter Scheper <Walter.Scheper@sas.com>