### PR TITLE
Adding Power support(ppc64le) with ci & testing to the project for architecture independent.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: python
+arch:
+  - amd64
+  - ppc64le
 
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.8"
 
 # Build inside docker containers instead of virtual machines. These are
 # faster, start quicker and support caching. Only downside: sudo is not


### PR DESCRIPTION
I am part of IBM team and working on porting power arch to packages as continuous integration & testing.
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly,
we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.

Pls verify and merge
